### PR TITLE
Fix error in photographs variable

### DIFF
--- a/examples/04-reduce/_setup.js
+++ b/examples/04-reduce/_setup.js
@@ -1,6 +1,4 @@
-var photographs = instagramAPI.data.filter(function (asset) {
-  return asset.type === 'image';
-}).slice(0, 16);
+var photographs = instagramAPI.data;
 
 var photographsDiv = document.getElementById('photographs');
 

--- a/examples/05-sort/_setup.js
+++ b/examples/05-sort/_setup.js
@@ -1,6 +1,4 @@
-var photographs = instagramAPI.data.filter(function (asset) {
-  return asset.type === 'image';
-}).slice(0, 16);
+var photographs = instagramAPI.data;
 
 var photographsDiv = document.getElementById('photographs');
 


### PR DESCRIPTION
As it was, `photographs` was returning the first 16 assets that were of type `image`. The first challenge in the `reduce` section has you count the number of likes for all images/videos, which it asserts should be 71. However, if you use `photographs` (and implement `reduce` correctly), you will only get 35 likes.

There are a few ways to fix this. I went with the easiest.

I'm not really sure why there is even a `slice` call being made on the API data we are handling. If we get rid of just that, our likes count will shoot up to 69, meaning that the other two likes the test is expecting are coming from the video(s). So we remove `asset.type === 'image;` and get

``` javascript
var photographs = instagramAPI.data.filter(function (asset) {
  return asset.type === 'image';
});
```

And voila, we now have 71 likes.
Of course, it is unnecessary to call `filter` on this array because we are no longer changing it, thus

``` javascript
var photographs = instagramAPI.data;
```

You could remove this line completely and just use `instagramAPI.data` directly in your solution code, but keeping the variable makes it easier to understand from the outside, and follows suit with the rest of the examples using a `photographs` variable.

Alternative solutions could have also included changing the test to expect 35 likes and not touch the setup code at all, or remove the `slice` call and expecting 69 likes. I figured changing the setup file and leaving the test alone was the best choice.

**UPDATE**:
The second commit for changing the `05-sort`'s `photographs` variable is less important since it won't trip up any tests (there currently are no tests), but I think it's useful so that people don't get unexpected results and have access to all images/videos.

The name of this branch should technically be renamed, but since it's already in a PR I can't rename it without deleting it and pushing up a new branch, which I don't want to do :)
